### PR TITLE
ARCH-1615 - Update syntax for setting outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ jobs:
       - name: Run Checkmarx with the defaults
         continue-on-error: true
         id: checkmarx
-        uses: im-open/checkmarx-cli-sast-scan@v2.0.2
+        uses: im-open/checkmarx-cli-sast-scan@v2.1.0
         with:
           checkmarx-server-url: ${{ secrets.CHECKMARX_URL }}
           checkmarx-username: ${{ secrets.CHECKMARX_USERNAME }}
@@ -157,7 +157,7 @@ jobs:
 
       - name: Run Checkmarx with the defaults
         id: scan
-        uses: im-open/checkmarx-cli-sast-scan@v2.0.2
+        uses: im-open/checkmarx-cli-sast-scan@v2.1.0
         with:
           checkmarx-server-url: ${{ secrets.CHECKMARX_URL }}
           checkmarx-username: ${{ secrets.CHECKMARX_USERNAME }}

--- a/action.yml
+++ b/action.yml
@@ -171,11 +171,11 @@ runs:
         info=$(echo $cxlog | grep -ioP 'Information severity results: \K(\d{1,4})')
         url=$(echo $cxlog | grep -ioP 'Scan results location: \K(http[s]*:+[^\s]+[\w])')
 
-        echo "::set-output name=HIGH::$(echo $high)"
-        echo "::set-output name=MED::$(echo $med)"
-        echo "::set-output name=LOW::$(echo $low)"
-        echo "::set-output name=INFO::$(echo $info)"
-        echo "::set-output name=URL::$(echo $url)"
+        echo "HIGH=$(echo $high)" >> $GITHUB_OUTPUT
+        echo "MED=$(echo $med)" >> $GITHUB_OUTPUT
+        echo "LOW=$(echo $low)" >> $GITHUB_OUTPUT
+        echo "INFO=$(echo $info)" >> $GITHUB_OUTPUT
+        echo "URL=$(echo $url)" >> $GITHUB_OUTPUT
 
     - name: Move Report to Root
       shell: bash


### PR DESCRIPTION
# Summary of PR changes

-  Update syntax for setting outputs to comply with the [GitHub's new recommendations](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands) to avoid logging untrusted data.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
