### PR TITLE
ARCH-1617 - Adding auto-update-readme workflow

### DIFF
--- a/.github/workflows/auto-update-readme.yml
+++ b/.github/workflows/auto-update-readme.yml
@@ -1,0 +1,61 @@
+name: Auto update readme for code changes
+on:
+  # This workflow uses the pull_request trigger which prevents write permissions and secrets
+  # access to the target repository from public forks.  This should remain as a pull_request
+  # trigger because checkout, build, format and checking for changes do not need elevated
+  # permissions to the repository.  The reduced permissions for public forks is adequate.
+  # Since this will commit readme/recompile changes back to the branch, special attention 
+  # should be paid to changes made to this workflow when reviewing the PR and granting 
+  # permission to first time contributors to run the workflow.
+  pull_request:
+  # Don't include any specific paths here so we always get a build that produces a status
+  # check that our Branch Protection Rules can use.  Having a status check also allows us
+  # to require that branches be up to date before they are merged.
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Check for code changes to the action
+        id: action-code
+        uses: im-open/did-custom-action-code-change@v1.0.1
+        with:
+          files-with-code: 'action.yml'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Get the next version for the readme if there are code changes to the action
+        if: steps.action-code.outputs.HAS_CHANGES == 'true'
+        id: version
+        uses: im-open/git-version-lite@v2.1.2
+        with:
+          create-ref: false
+          default-release-type: major
+
+      - name: Update readme with next version if there are code changes to the action
+        if: steps.action-code.outputs.HAS_CHANGES == 'true'
+        uses: im-open/update-action-version-in-file@v1.0.0
+        with:
+          file-to-update: './README.md'
+          action-name:  ${{ github.repository }}
+          updated-version: ${{ steps.version.outputs.NEXT_VERSION }}
+
+      - name: Commit unstaged readme changes if there are code changes to the action
+        if: steps.action-code.outputs.HAS_CHANGES == 'true'
+        run: |
+          if [[ "$(git status --porcelain)" != "" ]]; then
+            echo "There are changes to commit"
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git add .
+            git commit -m "Update readme with next version."
+            git push origin HEAD:${{ github.head_ref }}
+          else
+            echo "There were no changes to commit"
+          fi

--- a/README.md
+++ b/README.md
@@ -186,10 +186,17 @@ jobs:
 When creating new PRs please ensure:
 
 1. For major or minor changes, at least one of the commit messages contains the appropriate `+semver:` keywords listed under [Incrementing the Version](#incrementing-the-version).
-2. The `README.md` example has been updated with the new version. See [Incrementing the Version](#incrementing-the-version).
-3. The action code does not contain sensitive information.
+1. The action code does not contain sensitive information.
+
+When a pull request is created and there are changes to code-specific files and folders, the `auto-update-readme` workflow will run.  The workflow will update the action-examples in the README.md if they have not been updated manually by the PR author. The following files and folders contain action code and will trigger the automatic updates:
+
+- `action.yml`
+
+There may be some instances where the bot does not have permission to push changes back to the branch though so this step should be done manually for those branches. See [Incrementing the Version](#incrementing-the-version) for more details.
 
 ### Incrementing the Version
+
+The `auto-update-readme` and PR merge workflows will use the strategies below to determine what the next version will be.  If the `auto-update-readme` workflow was not able to automatically update the README.md action-examples with the next version, the README.md should be updated manually as part of the PR using that calculated version.
 
 This action uses [git-version-lite] to examine commit messages to determine whether to perform a major, minor or patch increment on merge. The following table provides the fragment that should be included in a commit message to active different increment strategies.
 | Increment Type | Commit Message Fragment |


### PR DESCRIPTION
# Summary of PR changes

Adding auto-update-readme workflow so it can update action version examples in the readme automatically.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - This should happen automatically as part of the build.  See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented if it did not.